### PR TITLE
feat: get the number of cells of the entry column of a table

### DIFF
--- a/kanon/tables/htable_reader.py
+++ b/kanon/tables/htable_reader.py
@@ -28,6 +28,7 @@ _dishas_fields = '","'.join(
         "entry_significant_fractional_place",
         "entry_number_unit",
         "entry_type_of_number",
+        "entry_number_of_cell",
         "symmetries",
         "edited_text",
         "table_type",
@@ -112,6 +113,8 @@ def read_table_content(
 
     entry_unit = tabc["entry_number_unit"]
     entry_shift = int(tabc["entry_significant_fractional_place"])
+
+    entry_cells = int(tabc["entry_number_of_cell"])
 
     argsvalues = values["args"]
 
@@ -219,6 +222,8 @@ def read_table_content(
         meta=tabc["edited_text"],
         table_type=table_type,
     )
+
+    table[entries_name].cells = entry_cells
 
     if freeze:
         table.freeze()

--- a/kanon/tables/tests/test_htable_reader.py
+++ b/kanon/tables/tests/test_htable_reader.py
@@ -1,6 +1,7 @@
 from kanon.tables.htable_reader import (
     read_historical,
     read_intsexag_array,
+    read_table_dishas,
     read_temporal,
 )
 from kanon.units import Historical, IntegerAndSexagesimal
@@ -25,3 +26,8 @@ def test_read_intsexag():
 def test_read_temporal():
     assert read_temporal([28, 18, 2, 6], 3, 1) == Temporal("28 ; 18,02,06")
     assert read_temporal([253, 18, 2, 6], 3, -1) == Temporal("-253 ; 18,02,06")
+
+
+def test_get_number_of_cells():
+    table = read_table_dishas(193)
+    assert 9 == table["Entries"].cells

--- a/kanon/tests/data/table_content-180.json
+++ b/kanon/tests/data/table_content-180.json
@@ -485,6 +485,7 @@
     "entry_type_of_number": "sexagesimal",
     "entry_number_unit": "degree",
     "entry_significant_fractional_place": "2",
+    "entry_number_of_cell": "1",
     "argument1_name": "Mean Argument of the Sun",
     "argument1_type_of_number": "integer and sexagesimal",
     "argument1_number_unit": "degree",

--- a/kanon/tests/data/table_content-287.json
+++ b/kanon/tests/data/table_content-287.json
@@ -1,6 +1,7 @@
 {
     "entry_significant_fractional_place": "2",
     "entry_type_of_number": "integer and sexagesimal",
+    "entry_number_of_cell": "0",
     "argument1_type_of_number": "historical",
     "argument2_significant_fractional_place": "0",
     "source_value_original": {


### PR DESCRIPTION
I am adding a `cell` variable to the entry `HColumn` of every single-entry table created from dishas to keep track of the number of columns of the historical table, with the information given by the `entry_number_of_cell` from the dishas' API (see #133 )